### PR TITLE
NYPL-148 docker update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *-settings.yml
 *.retry
+.DS_Store

--- a/circulation-server.yml
+++ b/circulation-server.yml
@@ -24,4 +24,4 @@
   pre_tasks:
     - include_vars: vars/circulation-settings.yml
   roles:
-  - simplye-circulation
+  - simplye-docker

--- a/roles/ec2/tasks/main.yml
+++ b/roles/ec2/tasks/main.yml
@@ -5,25 +5,27 @@
     region: "{{ aws_region }}"
   register: ec2_key
 
-- name: Save private key to local admin's .ssh directory
+- name: Save private key to local admins .ssh directory
   copy:
     content: "{{ ec2_key.key.private_key }}"
     dest: "~/.ssh/{{ simplye_instance_name }}.pem"
     mode: 0600
   when: ec2_key.changed
 
-- name: Create security group for EC2 insance and open SSH port to the ansible control machine
-  ec2_group:
-    name: "EC2-{{ simplye_role }}-{{ simplye_instance_name }}"
-    description: "Firewall rules for the {{ simplye_role }}-{{ simplye_instance_name }} RDS instance"
-    region: "{{ aws_region }}"
-    rules:
-      - proto: tcp
-        from_port: 22
-        to_port: 22
-        cidr_ip: "{{ admin_ip }}/32"
-  register: ec2_sg
-- debug: var=ec2_sg.group_id
+# This is commented out for now because the security role it creates doesn't allow the server to
+# go out and get package updates/new packages. The security role and groupID needs to be created manually.
+#- name: Create security group for EC2 insance and open SSH port to the ansible control machine
+#  ec2_group:
+#    name: "EC2-{{ simplye_role }}-{{ simplye_instance_name }}"
+#    description: "Firewall rules for the {{ simplye_role }}-{{ simplye_instance_name }} RDS instance"
+#    region: "{{ aws_region }}"
+#    rules:
+#      - proto: tcp
+#        from_port: 22
+#        to_port: 22
+#        cidr_ip: "{{ admin_ip }}/32"
+#  register: ec2_sg
+#- debug: var=ec2_sg.group_id
 
 - name: Create a new server instance in AWS EC2 if none exist with tag "{{ simplye_role }}-{{ simplye_instance_name }}"
   local_action:
@@ -37,7 +39,7 @@
       Name: "{{ simplye_role }}-{{ simplye_instance_name }}"
     instance_tags: '{"Name":"{{ simplye_role }}-{{ simplye_instance_name }}","Type":"{{ simplye_role }}","Environment":"{{ simplye_environment }}"}'
     key_name: "{{ simplye_instance_name }}"
-    group_id: "{{ ec2_sg.group_id }}"
+    group_id: "sg-d0b578ab"
     image: "{{ ec2_image }}"
     vpc_subnet_id: "{{ ec2_subnet_ids|random }}"
     assign_public_ip: yes

--- a/roles/ec2/tasks/main.yml
+++ b/roles/ec2/tasks/main.yml
@@ -12,20 +12,23 @@
     mode: 0600
   when: ec2_key.changed
 
-# This is commented out for now because the security role it creates doesn't allow the server to
-# go out and get package updates/new packages. The security role and groupID needs to be created manually.
-#- name: Create security group for EC2 insance and open SSH port to the ansible control machine
-#  ec2_group:
-#    name: "EC2-{{ simplye_role }}-{{ simplye_instance_name }}"
-#    description: "Firewall rules for the {{ simplye_role }}-{{ simplye_instance_name }} RDS instance"
-#    region: "{{ aws_region }}"
-#    rules:
-#      - proto: tcp
-#        from_port: 22
-#        to_port: 22
-#        cidr_ip: "{{ admin_ip }}/32"
-#  register: ec2_sg
-#- debug: var=ec2_sg.group_id
+- name: Create security group for EC2 insance and open SSH port to the ansible control machine
+  ec2_group:
+    name: "EC2-{{ simplye_role }}-{{ simplye_instance_name }}"
+    description: "Firewall rules for the {{ simplye_role }}-{{ simplye_instance_name }} RDS instance"
+    region: "{{ aws_region }}"
+    rules:
+      - proto: all
+        from_port: all
+        to_port: all
+        cidr_ip: 0.0.0.0/0
+    rules_egress:
+      - proto: all
+        from_port: all
+        to_port: all
+        cidr_ip: 0.0.0.0/0
+  register: ec2_sg
+- debug: var=ec2_sg.group_id
 
 - name: Create a new server instance in AWS EC2 if none exist with tag "{{ simplye_role }}-{{ simplye_instance_name }}"
   local_action:
@@ -39,7 +42,7 @@
       Name: "{{ simplye_role }}-{{ simplye_instance_name }}"
     instance_tags: '{"Name":"{{ simplye_role }}-{{ simplye_instance_name }}","Type":"{{ simplye_role }}","Environment":"{{ simplye_environment }}"}'
     key_name: "{{ simplye_instance_name }}"
-    group_id: "sg-d0b578ab"
+    group_id: "{{ ec2_sg.group_id }}"
     image: "{{ ec2_image }}"
     vpc_subnet_id: "{{ ec2_subnet_ids|random }}"
     assign_public_ip: yes

--- a/roles/linux/tasks/main.yml
+++ b/roles/linux/tasks/main.yml
@@ -14,7 +14,17 @@
     gpgcheck: yes
 
 - name: Install yum package dependencies
-  yum: name=cairo,elasticsearch,git,libffi-devel,nginx,openssl-devel,postgresql,postgresql-devel,python27,python27-devel,python-nose,python-sqlalchemy,python-pip state=latest
+  yum: name=cairo,elasticsearch,git,libffi-devel,nginx,openssl-devel,postgresql,postgresql-devel,python27,python27-devel,python-nose,python-sqlalchemy,python-pip,docker state=latest
+
+- name: Install docker-py globally from pip
+  pip: name=docker-py state=latest
+  sudo: yes
+
+- name: Add ec2-user to Docker group
+  user:
+    name: ec2-user
+    groups: docker
+    append: yes
 
 - name: Copy the nginx.conf file to the server
   copy:
@@ -32,5 +42,11 @@
 - name: Make sure elasticsearch is running and configured to start at boot
   service:
     name: elasticsearch
+    state: started
+    enabled: yes
+
+- name: Make sure docker is running and configured to start at boot
+  service:
+    name: docker
     state: started
     enabled: yes

--- a/roles/simplye-circulation/tasks/main.yml
+++ b/roles/simplye-circulation/tasks/main.yml
@@ -1,15 +1,15 @@
 ---
 - name: Install virtualenv globally from pip
   pip: name=virtualenv state=latest
-
+  sudo: yes
 
 - name: Install virtualenvwrapper globally from pip
   pip: name=virtualenvwrapper state=latest
-
+  sudo: yes
 
 - name: Install textblob globally from pip
   pip: name=virtualenvwrapper state=latest
-
+  sudo: yes
 
 - name: Copy the SSH private key file to the server to allow GitHub access
   copy:

--- a/roles/simplye-docker/files/circulation.conf
+++ b/roles/simplye-docker/files/circulation.conf
@@ -1,0 +1,14 @@
+server {
+    listen      80 deferred;
+    server_name localhost;
+    charset     utf-8;
+    client_max_body_size 75M;
+    merge_slashes off;
+
+    location / { try_files $uri @circulation; }
+    location @circulation {
+        include uwsgi_params;
+        uwsgi_read_timeout 120;
+        uwsgi_pass unix:/var/www/circulation/uwsgi.sock;
+    }
+}

--- a/roles/simplye-docker/files/uwsgi.ini
+++ b/roles/simplye-docker/files/uwsgi.ini
@@ -1,0 +1,26 @@
+[uwsgi]
+#application's base folder
+base = /var/www/circulation
+home = %(base)/env
+pythonpath = %(base)
+
+#python module to import
+module = api.app
+callable = app
+
+#socket file's location
+socket = /var/www/circulation/%n.sock
+
+#permissions for the socket file
+chmod-socket = 666
+
+#location of log files
+logto = /var/www/circulation/%n.log
+log-format = %(addr) - - [%(ltime)] "%(method) %(uri) %(proto)" %(status) %(size) "%(referer)" "%(uagent)" host_hdr=%(host) req_time_elapsed=%(msecs)
+
+processes = 6
+threads = 2
+harakiri = 300
+lazy-apps = true
+touch-reload=uwsgi.ini
+buffer-size=131072

--- a/roles/simplye-docker/tasks/main.yml
+++ b/roles/simplye-docker/tasks/main.yml
@@ -1,0 +1,84 @@
+---
+- name: Pull and start docker container
+  docker_container:
+    name: "circman"
+    pull: true
+    image: {{ docker_image }}:{{ docker_tag }}
+    starte: started
+
+
+
+
+
+
+- name: Install virtualenv globally from pip
+  pip: name=virtualenv state=latest
+  sudo: yes
+
+- name: Install virtualenvwrapper globally from pip
+  pip: name=virtualenvwrapper state=latest
+  sudo: yes
+
+- name: Install textblob globally from pip
+  pip: name=virtualenvwrapper state=latest
+  sudo: yes
+
+- name: Copy the SSH private key file to the server to allow GitHub access
+  copy:
+    src: "{{ git_ssh_priv_key }}"
+    dest: "~/.ssh/id_rsa"
+    mode: 0600
+
+- name: Create /var/www/{{ simplye_role }} directory
+  file:
+    path: "/var/www/{{ simplye_role }}"
+    state: directory
+    owner: ec2-user
+    group: ec2-user
+    mode: 0755
+  become: yes
+
+- name: Clone "{{ simplye_repo }}" w/submodules
+  git:
+    repo: "{{ simplye_repo }}"
+    dest: "/var/www/{{ simplye_role }}"
+    accept_hostkey: true
+
+- name: Install python requirements from requirements.txt into a new python virtualenv
+  pip:
+    virtualenv: "/var/www/{{ simplye_role }}/env"
+    virtualenv_python: python2.7
+    virtualenv_command: virtualenv
+    requirements: "/var/www/{{ simplye_role }}/requirements.txt"
+
+- name: Write the config.json to the server
+  template:
+    src: templates/config.j2
+    dest: "/var/www/config.json"
+    owner: ec2-user
+    group: ec2-user
+    mode: 0666
+
+- name: Add configuration file location to python virtuanenv
+  lineinfile:
+    dest: "/var/www/{{ simplye_role }}/env/bin/activate"
+    line: "export SIMPLIFIED_CONFIGURATION_FILE=/var/www/config.json"
+  become: yes
+
+- name: Create nginx config file
+  copy:
+    src: files/circulation.conf
+    dest: /etc/nginx/conf.d/circulation.conf
+    mode: 0644
+  become: yes
+
+- name: Restart nginx
+  service:
+    name: nginx
+    state: restarted
+
+- name: Create uwsgi config file
+  copy:
+    src: files/uwsgi.ini
+    dest: "/var/www/circulation/uwsgi.ini"
+    mode: 0644

--- a/roles/simplye-docker/tasks/main.yml
+++ b/roles/simplye-docker/tasks/main.yml
@@ -1,84 +1,34 @@
 ---
-- name: Pull and start docker container
-  docker_container:
-    name: "circman"
-    pull: true
-    image: {{ docker_image }}:{{ docker_tag }}
-    starte: started
-
-
-
-
-
-
-- name: Install virtualenv globally from pip
-  pip: name=virtualenv state=latest
-  sudo: yes
-
-- name: Install virtualenvwrapper globally from pip
-  pip: name=virtualenvwrapper state=latest
-  sudo: yes
-
-- name: Install textblob globally from pip
-  pip: name=virtualenvwrapper state=latest
-  sudo: yes
-
-- name: Copy the SSH private key file to the server to allow GitHub access
-  copy:
-    src: "{{ git_ssh_priv_key }}"
-    dest: "~/.ssh/id_rsa"
-    mode: 0600
-
-- name: Create /var/www/{{ simplye_role }} directory
-  file:
-    path: "/var/www/{{ simplye_role }}"
-    state: directory
-    owner: ec2-user
-    group: ec2-user
-    mode: 0755
-  become: yes
-
-- name: Clone "{{ simplye_repo }}" w/submodules
-  git:
-    repo: "{{ simplye_repo }}"
-    dest: "/var/www/{{ simplye_role }}"
-    accept_hostkey: true
-
-- name: Install python requirements from requirements.txt into a new python virtualenv
-  pip:
-    virtualenv: "/var/www/{{ simplye_role }}/env"
-    virtualenv_python: python2.7
-    virtualenv_command: virtualenv
-    requirements: "/var/www/{{ simplye_role }}/requirements.txt"
-
 - name: Write the config.json to the server
   template:
     src: templates/config.j2
-    dest: "/var/www/config.json"
+    dest: "/home/ec2-user/config.json"
     owner: ec2-user
     group: ec2-user
     mode: 0666
 
-- name: Add configuration file location to python virtuanenv
-  lineinfile:
-    dest: "/var/www/{{ simplye_role }}/env/bin/activate"
-    line: "export SIMPLIFIED_CONFIGURATION_FILE=/var/www/config.json"
-  become: yes
+- name: Pull and start scripts container
+  docker_container:
+    name: "circ-scripts"
+    pull: true
+    image: "{{ docker_scripts }}:{{ docker_scripts_tag }}"
+    state: started
+    env:
+        LIBSIMPLE_DB_INIT: "{{ initialize_db }}"
+    volumes:
+      - /home/ec2-user:/etc/circulation
 
-- name: Create nginx config file
-  copy:
-    src: files/circulation.conf
-    dest: /etc/nginx/conf.d/circulation.conf
-    mode: 0644
-  become: yes
-
-- name: Restart nginx
-  service:
-    name: nginx
-    state: restarted
-
-- name: Create uwsgi config file
-  copy:
-    src: files/uwsgi.ini
-    dest: "/var/www/circulation/uwsgi.ini"
-    mode: 0644
+- name: Pull and start circulation manager deployment container
+  docker_container:
+    name: "circ-deploy"
+    pull: true
+    image: "{{ docker_deploy }}:{{ docker_deploy_tag }}"
+    state: started
+    expose:
+      - 80
+    ports:
+      - "80:80"
+    env:
+        LIBSIMPLE_DB_INIT: "{{ initialize_db }}"
+    volumes:
+      - /home/ec2-user:/etc/circulation

--- a/templates/config.j2
+++ b/templates/config.j2
@@ -1,18 +1,10 @@
 {
-    "default_notification_email_address" : "{{ admin_email }}",
-
-    "policies" : {
-
-		"holds" : "allow",
+  "default_notification_email_address" : "{{ admin_email }}",
+  "policies" : {
+    "holds" : "allow",
     "languages" : {
-
-        "large_collections" : ["eng"],
-
-        "small_collections" : ["eng"]
-
-      },
-
-
+      "large_collections" : ["eng"]
+    },
     "authentication": {
         "providers": [
             { "module": "api.mock_authentication",
@@ -23,67 +15,36 @@
     }
 },
     "integrations" : {
+        "Postgres" : {
+            "production_url" : "postgresql://{{ psql_username }}:{{ psql_password }}@{{ hostvars['localhost']['rds']['instance']['endpoint'] }}:5432/{{ psql_db_name }}"
 
-		"Postgres" : {
-
-			"production_url" : "postgresql://{{ psql_username }}:{{ psql_password }}@{{ hostvars['localhost']['rds']['instance']['endpoint'] }}:5432/{{ psql_db_name }}"
-
-		},
-
-
-		"Elasticsearch" : {
-
-			"url" : "http://localhost:9200",
-
-			"works_index" : "circulation-works"
-		},
-
+        },
+    "Elasticsearch" : {
+        "url" : "http://localhost:9200",
+        "works_index" : "circulation-works"
+    },
     "Metadata Wrangler" : {
-
-        "url" : "http://metadata.alpha.librarysimplified.org/"
-
+        "url" : "http://metadata.librarysimplified.org/"
       },
-
-      "Content Server" : {
-
-        "url" : "http://oacontent.alpha.librarysimplified.org/"
-
-      },
-
-      "Circulation Manager" : {
-
-        "url" : "http://{{ ansible_hostname }}"
-
-      },
-
-		"Overdrive" : {
-
-			"client_key" : "{{ od_client_key }}",
-
-			"client_secret" : "{{ od_client_secret }}",
-
-			"website_id" : "{{ od_website_id }}",
-
-			"library_id" : "{{ od_library_id }}",
-
-			"ils_name": "{{ od_ils_name }}",
-
-			"cname_url": "{{ od_cname_url }}",
-
-			"default_loan_period": "{{ od_default_loan_period }}"
-
-		},
-
-		"3M" : {
-
-			"library_id" : "{{ threem_library_id }}",
-
-			"account_id" : "{{ threem_account_id }}",
-
-			"account_key" : "{{ threem_account_key }}"
-
-		}
-
+    "Content Server" : {
+        "url" : "http://oacontent.librarysimplified.org/"
+    },
+    "Circulation Manager" : {
+         "url" : "http://{{ ansible_hostname }}"
+    },
+    "Overdrive" : {
+         "client_key" : "{{ od_client_key }}",
+         "client_secret" : "{{ od_client_secret }}",
+         "website_id" : "{{ od_website_id }}",
+         "library_id" : "{{ od_library_id }}",
+         "ils_name": "{{ od_ils_name }}",
+         "cname_url": "{{ od_cname_url }}",
+         "default_loan_period": "{{ od_default_loan_period }}"
+    },
+    "3M" : {
+         "library_id" : "{{ threem_library_id }}",
+         "account_id" : "{{ threem_account_id }}",
+         "account_key" : "{{ threem_account_key }}"
     }
-
+  }
 }

--- a/templates/config.j2
+++ b/templates/config.j2
@@ -17,11 +17,11 @@
         }
       ]
     }
-},
-    "integrations" : {
-      "Postgres" : {
-        "production_url" : "postgresql://{{ psql_username }}:{{ psql_password }}@{{ hostvars['localhost']['rds']['instance']['endpoint'] }}:5432/{{ psql_db_name }}"
-      },
+  },
+  "integrations" : {
+    "Postgres" : {
+      "production_url" : "postgresql://{{ psql_username }}:{{ psql_password }}@{{ hostvars['localhost']['rds']['instance']['endpoint'] }}:5432/{{ psql_db_name }}"
+    },
     "Elasticsearch" : {
       "url" : "http://localhost:9200",
       "works_index" : "circulation-works"
@@ -48,11 +48,12 @@
       "library_id" : "{{ threem_library_id }}",
       "account_id" : "{{ threem_account_id }}",
       "account_key" : "{{ threem_account_key }}"
-    }
+    },
     "Axis 360" : {
       "username" : "{{ axis_username }}",
       "password" : "{{ axis_password }}",
       "library_id" : "{{ axis_library_id }}",
       "server" : "{{ axis_qa_prod }}"
+    }
   }
 }

--- a/templates/config.j2
+++ b/templates/config.j2
@@ -6,45 +6,53 @@
       "large_collections" : ["eng"]
     },
     "authentication": {
-        "providers": [
-            { "module": "api.mock_authentication",
-              "patrons": { "patron1": "password",
-                           "patron2": "password2" }
-            }
-        ]
+      "providers": [
+        { "module": "api.sip",
+          "server": "{{ auth_server }}",
+          "port": {{ auth_port }},
+          "login_user_id": "{{ auth_username }}",
+          "login_password": "{{ auth_password }}",
+          "location_code": "{{ auth_location }}",
+          "field_separator": "{{ auth_separator }}"
+        }
+      ]
     }
 },
     "integrations" : {
-        "Postgres" : {
-            "production_url" : "postgresql://{{ psql_username }}:{{ psql_password }}@{{ hostvars['localhost']['rds']['instance']['endpoint'] }}:5432/{{ psql_db_name }}"
-
-        },
+      "Postgres" : {
+        "production_url" : "postgresql://{{ psql_username }}:{{ psql_password }}@{{ hostvars['localhost']['rds']['instance']['endpoint'] }}:5432/{{ psql_db_name }}"
+      },
     "Elasticsearch" : {
-        "url" : "http://localhost:9200",
-        "works_index" : "circulation-works"
+      "url" : "http://localhost:9200",
+      "works_index" : "circulation-works"
     },
     "Metadata Wrangler" : {
-        "url" : "http://metadata.librarysimplified.org/"
-      },
+      "url" : "http://metadata.librarysimplified.org/"
+    },
     "Content Server" : {
-        "url" : "http://oacontent.librarysimplified.org/"
+      "url" : "http://oacontent.librarysimplified.org/"
     },
     "Circulation Manager" : {
-         "url" : "http://{{ ansible_hostname }}"
+      "url" : "http://{{ ansible_hostname }}"
     },
     "Overdrive" : {
-         "client_key" : "{{ od_client_key }}",
-         "client_secret" : "{{ od_client_secret }}",
-         "website_id" : "{{ od_website_id }}",
-         "library_id" : "{{ od_library_id }}",
-         "ils_name": "{{ od_ils_name }}",
-         "cname_url": "{{ od_cname_url }}",
-         "default_loan_period": "{{ od_default_loan_period }}"
+      "client_key" : "{{ od_client_key }}",
+      "client_secret" : "{{ od_client_secret }}",
+      "website_id" : "{{ od_website_id }}",
+      "library_id" : "{{ od_library_id }}",
+      "ils_name": "{{ od_ils_name }}",
+      "cname_url": "{{ od_cname_url }}",
+      "default_loan_period": "{{ od_default_loan_period }}"
     },
     "3M" : {
-         "library_id" : "{{ threem_library_id }}",
-         "account_id" : "{{ threem_account_id }}",
-         "account_key" : "{{ threem_account_key }}"
+      "library_id" : "{{ threem_library_id }}",
+      "account_id" : "{{ threem_account_id }}",
+      "account_key" : "{{ threem_account_key }}"
     }
+    "Axis 360" : {
+      "username" : "{{ axis_username }}",
+      "password" : "{{ axis_password }}",
+      "library_id" : "{{ axis_library_id }}",
+      "server" : "{{ axis_qa_prod }}"
   }
 }

--- a/vars/circulation-settings.sample
+++ b/vars/circulation-settings.sample
@@ -8,30 +8,35 @@ simplye_role: "circulation" # can be one of: "circulation" "content" "metadata"
 simplye_instance_name: (REQUIRED) # e.g. "FooPublicLibrary"
 simplye_environment: "production"
 
-auth_server: (REQUIRED)
-auth_port: (REQUIRED)
-auth_username: (REQUIRED)
-auth_password: (REQUIRED)
-auth_location: (REQUIRED)
-auth_separator: (REQUIRED)
+auth_server: ""
+auth_port: ""
+auth_username: ""
+auth_password: ""
+auth_location: ""
+auth_separator: ""
 
 simplye_repo: "git@github.com:NYPL-Simplified/circulation.git"
 
 # Docker information
-docker_repo : ""
-docker_tag : ""
+docker_scripts: "nypl/circ-scripts"
+docker_scripts_tag : "latest"
+docker_deploy: "nypl/circ-deploy"
+docker_deploy_tag: "latest"
+
+initialize_db: true # this should be true only when using this database and Elasticsearch instance for the first time
 
 # AWS shared
 aws_region: "us-west-2"
 
 # AWS EC2
-ec2_instance_type: "t2.micro"
-ec2_image: "ami-b04e92d0"
+ec2_instance_type: "t2.large"
+ec2_image: "ami-8ca83fec"
 ec2_volume_size: 32
 ec2_subnet_ids: (REQUIRED) # @ToDo: automate this: http://docs.ansible.com/ansible/ec2_vpc_subnet_module.html
+# until it's automated, these can be found in EC2 -> Network & Security -> Network Interfaces
 
 # AWS RDS & PostgreSQL
-rds_instance_type: "db.t2.micro"
+rds_instance_type: "db.t2.medium"
 rds_db_engine: "postgres"
 rds_size: 100
 rds_subnet: (REQUIRED) # @ToDo: automate this: http://docs.ansible.com/ansible/ec2_vpc_subnet_module.html
@@ -39,10 +44,6 @@ rds_subnet: (REQUIRED) # @ToDo: automate this: http://docs.ansible.com/ansible/e
 psql_db_name: "scripts"
 psql_username: (REQUIRED)
 psql_password: (REQUIRED)
-
-# Docker
-docker_image: (REQUIRED)
-docker_tag: latest
 
 # Vendor vars
 #############

--- a/vars/circulation-settings.sample
+++ b/vars/circulation-settings.sample
@@ -8,7 +8,18 @@ simplye_role: "circulation" # can be one of: "circulation" "content" "metadata"
 simplye_instance_name: (REQUIRED) # e.g. "FooPublicLibrary"
 simplye_environment: "production"
 
+auth_server: (REQUIRED)
+auth_port: (REQUIRED)
+auth_username: (REQUIRED)
+auth_password: (REQUIRED)
+auth_location: (REQUIRED)
+auth_separator: (REQUIRED)
+
 simplye_repo: "git@github.com:NYPL-Simplified/circulation.git"
+
+# Docker information
+docker_repo : ""
+docker_tag : ""
 
 # AWS shared
 aws_region: "us-west-2"
@@ -29,6 +40,10 @@ psql_db_name: "scripts"
 psql_username: (REQUIRED)
 psql_password: (REQUIRED)
 
+# Docker
+docker_image: (REQUIRED)
+docker_tag: latest
+
 # Vendor vars
 #############
 
@@ -45,3 +60,9 @@ od_default_loan_period: (REQUIRED)
 threem_library_id: (REQUIRED)
 threem_account_id: (REQUIRED)
 threem_account_key : (REQUIRED)
+
+# Axis360
+axis_username: (REQUIRED)
+axis_password: (REQUIRED)
+axis_library_id: (REQUIRED)
+axis_qa_prod: (REQUIRED)

--- a/vars/circulation-settings.sample
+++ b/vars/circulation-settings.sample
@@ -9,7 +9,7 @@ simplye_instance_name: (REQUIRED) # e.g. "FooPublicLibrary"
 simplye_environment: "production"
 
 auth_server: ""
-auth_port: ""
+auth_port: "80"
 auth_username: ""
 auth_password: ""
 auth_location: ""

--- a/vars/circulation-settings.sample
+++ b/vars/circulation-settings.sample
@@ -34,12 +34,14 @@ ec2_image: "ami-8ca83fec"
 ec2_volume_size: 32
 ec2_subnet_ids: (REQUIRED) # @ToDo: automate this: http://docs.ansible.com/ansible/ec2_vpc_subnet_module.html
 # until it's automated, these can be found in EC2 -> Network & Security -> Network Interfaces
+# it should be a list in the form ["subnet1","subnet2","subnet3"]
 
 # AWS RDS & PostgreSQL
 rds_instance_type: "db.t2.medium"
 rds_db_engine: "postgres"
 rds_size: 100
 rds_subnet: (REQUIRED) # @ToDo: automate this: http://docs.ansible.com/ansible/ec2_vpc_subnet_module.html
+# this can simply be "default" for now
 
 psql_db_name: "scripts"
 psql_username: (REQUIRED)


### PR DESCRIPTION
Addresses [NYPL-149](https://jira.datalogics.com/browse/NYPL-149) (subtask of NYPL-148).

Ultimately, we want to install the Circulation Manager using Docker _and_ EC2 Container Service. This PR does only the former, but it brings us much closer to the functionality we want compared to where it was before.

Also, note that the files in roles/simplye-docker/files were copied from roles/simplye-circulation/files without modification.

Further documentation on how this works, plus limitations, is here: https://wiki.datalogics.com/display/EN/Repeatable+Installation+Steps