### PR TITLE
Fix ‘logn' to ‘loan’

### DIFF
--- a/vars/circulation-settings.sample
+++ b/vars/circulation-settings.sample
@@ -77,4 +77,4 @@ axis_qa_prod: ""
 # OneClick
 oneclick_libid: ""
 oneclick_token: ""
-oneclick_logn_length: ""
+oneclick_loan_length: ""


### PR DESCRIPTION
Small typo fix to prevent the error

FAILED! => {"changed": false, "failed": true, "msg": "AnsibleUndefinedVariable: 'oneclick_loan_length' is undefined"}